### PR TITLE
Fix logs format

### DIFF
--- a/util/log.go
+++ b/util/log.go
@@ -6,9 +6,9 @@ import (
 )
 
 func LogError(scope, format string, a ...interface{}) {
-	fmt.Fprintf(color.Output, "%s: %s", color.New(color.FgRed, color.Bold).Sprint(scope), fmt.Sprintf(format, a))
+	fmt.Fprintf(color.Output, "%s: %s\n", color.New(color.FgRed, color.Bold).Sprint(scope), fmt.Sprintf(format, a...))
 }
 
 func LogInfo(scope, format string, a ...interface{}) {
-	fmt.Fprintf(color.Output, "%s: %s", color.New(color.FgGreen, color.Bold).Sprint(scope), fmt.Sprintf(format, a))
+	fmt.Fprintf(color.Output, "%s: %s\n", color.New(color.FgGreen, color.Bold).Sprint(scope), fmt.Sprintf(format, a...))
 }


### PR DESCRIPTION
Running your hello world in your README the first time, 
```
> cat hello.ts
import { hello } from "https://x.nest.land/arweave-hello@0.0.2/mod.ts";

hello("Elsa");

> elsa run hello.ts
Hello, Elsa
```
The output is:

> Downloading: https://x.nest.land/arweave-hello@0.0.2/mod.ts => /tmp/x.nest.land/arweave-hello@0.0.2/mod.ts%!(EXTRA []interface {}=[])Hi Elsa!

This PR fixes the call with the format string and adds a newline to the log. Output:

> Downloading: https://x.nest.land/arweave-hello@0.0.2/mod.ts => /tmp/x.nest.land/arweave-hello@0.0.2/mod.ts
> Hi Elsa!