### PR TITLE
fix: use correct spelling of JavaScript and TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# ignore the bundled typescript source
+# ignore the bundled TypeScript source
 *.js linguist-vendored

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img align="right" src=assets/logo.svg height="120px">
 
-Elsa is a _minimal_, _fast_ and _secure_ runtime for Javascript and Typescript written in Go, leveraging the power from [QuickJS](https://bellard.org/quickjs/).
+Elsa is a _minimal_, _fast_ and _secure_ runtime for JavaScript and TypeScript written in Go, leveraging the power from [QuickJS](https://bellard.org/quickjs/).
 
 ### Features
 
@@ -63,7 +63,7 @@ Start by creating an issue about your feature or bug! Then, create a PR and we'l
 
 **Why choose QuickJS over V8?**
 
-QuickJS is a small and embeddable Javascript engine but it lacks V8's JIT for fast JavaScript execution. Although, it doesn't mean you cannot use Elsa on backends and CPU intensive tasks.
+QuickJS is a small and embeddable JavaScript engine but it lacks V8's JIT for fast JavaScript execution. Although, it doesn't mean you cannot use Elsa on backends and CPU intensive tasks.
 
 QuickJS has a better startup time than V8 so it would be a strong alternative for CLI apps and short-lived runs.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,13 +39,13 @@ func Execute(elsa Elsa) {
 	// Rool command
 	var rootCmd = &cobra.Command{
 		Use:   "elsa [file]",
-		Short: "Elsa is a simple Javascript and Typescript runtime written in Go",
+		Short: "Elsa is a simple JavaScript and TypeScript runtime written in Go",
 	}
 
 	// Run subcommand
 	var runCmd = &cobra.Command{
 		Use:   "run [file]",
-		Short: "Run a Javascript and Typescript source file",
+		Short: "Run a JavaScript and TypeScript source file",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) >= 0 {
@@ -74,7 +74,7 @@ func Execute(elsa Elsa) {
 	var devCmd = &cobra.Command{
 		Use:   "dev [file]",
 		Short: "Run a script in development mode.",
-		Long:  `Run a script in development mode. It enables type-checking using the inbuilt typescript compiler.`,
+		Long:  `Run a script in development mode. It enables type-checking using the inbuilt TypeScript compiler.`,
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) >= 0 {
@@ -99,8 +99,8 @@ func Execute(elsa Elsa) {
 	// bundle subcommand to bundle a source file
 	var bundleCmd = &cobra.Command{
 		Use:   "bundle [file]",
-		Short: "Bundle your script to a single javascript file",
-		Long:  `Bundle your script to a single javascript file. It utilizes esbuild for super fast bundling.`,
+		Short: "Bundle your script to a single JavaScript file",
+		Long:  `Bundle your script to a single JavaScript file. It utilizes esbuild for super fast bundling.`,
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) >= 0 {

--- a/core/console.go
+++ b/core/console.go
@@ -14,7 +14,7 @@ var f = NewFormatter()
 // ConsoleLog console.log bindings to quickjs engine
 func ConsoleLog(ctx *quickjs.Context, value []quickjs.Value) quickjs.Value {
 	data := value[2]
-	// dataType is the javascript type of the data => `typeof arg`
+	// dataType is the JavaScript type of the data => `typeof arg`
 	dataType := value[1].String()
 	var result interface{}
 	switch dataType {

--- a/core/dispatch.go
+++ b/core/dispatch.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// ElsaSendNS Native function corresponding to the Javascript global `__send`
+// ElsaSendNS Native function corresponding to the JavaScript global `__send`
 // It is binded with `__send` and accepts arguments including op ID
 func ElsaSendNS(elsa *options.Elsa) func(ctx *quickjs.Context, this quickjs.Value, args []quickjs.Value) quickjs.Value {
 	// Create a new file system driver
@@ -116,7 +116,7 @@ func CheckNet(perms *options.Perms) {
 	}
 }
 
-// ElsaRecvNS Native function corresponding to the Javascript global `__recv`
+// ElsaRecvNS Native function corresponding to the JavaScript global `__recv`
 // It is binded with `__recv` and accepts arguments including recv ID of the async function
 func ElsaRecvNS(elsa *options.Elsa) func(ctx *quickjs.Context, this quickjs.Value, args []quickjs.Value) quickjs.Value {
 	// the returned function handles the __recv behaviour

--- a/dev/report.go
+++ b/dev/report.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elsaland/quickjs"
 )
 
-// ReportDiagnostics report typescript diagnostics
+// ReportDiagnostics report TypeScript diagnostics
 func ReportDiagnostics(diagnostics quickjs.Value) {
 	diag := diagnostics.String()
 	if diag != "" {

--- a/std/async/deferred.ts
+++ b/std/async/deferred.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 // TODO(ry) It'd be better to make Deferred a class that inherits from
 // Promise, rather than an interface. This is possible in ES2016, however
-// typescript produces broken code when targeting ES5 code.
+// TypeScript produces broken code when targeting ES5 code.
 // See https://github.com/Microsoft/TypeScript/issues/15202
 // At the time of writing, the github issue is closed but the problem remains.
 export interface Deferred<T> extends Promise<T> {

--- a/std/hash/aes.ts
+++ b/std/hash/aes.ts
@@ -18,7 +18,7 @@
 type BitSize = "128" | "192" | "256";
 
 /**
- * implementation of AES ( Advanced Encryption Standard ) in typescript
+ * implementation of AES ( Advanced Encryption Standard ) in TypeScript
  */
 
 export class AES {


### PR DESCRIPTION
Would be good to update the repo description also, but I don't have the rights to do so 😅  
![image](https://user-images.githubusercontent.com/2852660/95523899-95752380-09d8-11eb-8d1b-697899233288.png)
